### PR TITLE
Centralize DB connections

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -1,0 +1,37 @@
+<?php
+require_once '/var/www/html/vendor/autoload.php';
+
+function getMongoDb(): MongoDB\Database {
+    static $db = null;
+    if ($db === null) {
+        $mongoUri   = 'mongodb://Irdi:Password1@MyMongoDBContainer:27017';
+        $client = new MongoDB\Client($mongoUri);
+        $db = $client->selectDatabase('IMSE_MS2');
+    }
+    return $db;
+}
+
+function getPDO(): PDO {
+    static $pdo = null;
+    if ($pdo === null) {
+        $host = 'MySQLDockerContainer';
+        $db   = 'IMSE_MS2';
+        $user = 'root';
+        $pass = 'IMSEMS2';
+        $dsn  = "mysql:host=$host;dbname=$db;charset=utf8mb4";
+        $pdo = new PDO($dsn, $user, $pass);
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    }
+    return $pdo;
+}
+
+function getMySQLi(): mysqli {
+    static $mysqli = null;
+    if ($mysqli === null) {
+        $mysqli = new mysqli('MySQLDockerContainer', 'root', 'IMSEMS2', 'IMSE_MS2');
+        if ($mysqli->connect_error) {
+            throw new Exception('MySQL connection error: ' . $mysqli->connect_error);
+        }
+    }
+    return $mysqli;
+}

--- a/src/generate_data_using_faker.php
+++ b/src/generate_data_using_faker.php
@@ -1,20 +1,10 @@
 <?php
-require_once __DIR__ . '/vendor/autoload.php'; // Composer autoload
+require_once __DIR__ . '/db.php';
 
 use Faker\Factory as FakerFactory;
 
-$host   = 'MySQLDockerContainer'; // MySQL container name
-$dbname = 'IMSE_MS2';             // Database name
-$user   = 'root';                 // MySQL username
-$pass   = 'IMSEMS2';              // MySQL root password
+$pdo = getPDO();
 
-try {
-    $pdo = new PDO("mysql:host=$host;dbname=$dbname;charset=utf8mb4", $user, $pass, [
-        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
-    ]);
-} catch (Exception $e) {
-    die("Could not connect to the database. Error: " . $e->getMessage());
-}
 
 //Faker instance
 $faker = FakerFactory::create();

--- a/src/get_aisles.php
+++ b/src/get_aisles.php
@@ -1,10 +1,5 @@
 <?php
-require_once '/var/www/html/vendor/autoload.php';
-
-$host = 'MySQLDockerContainer';
-$db = 'IMSE_MS2';
-$user = 'root';
-$pass = 'IMSEMS2';
+require_once __DIR__ . '/db.php';
 
 header('Content-Type: application/json');
 
@@ -14,9 +9,7 @@ if (isset($_GET['warehouse_id'])) {
 
     if ($useMongoDB) {
         try {
-            $mongoUri = 'mongodb://Irdi:Password1@MyMongoDBContainer:27017';
-            $mongoClient = new MongoDB\Client($mongoUri);
-            $mongoDb = $mongoClient->selectDatabase('IMSE_MS2');
+            $mongoDb = getMongoDb();
 
             $warehouse = $mongoDb->Warehouse->findOne(['warehouseID' => (int)$warehouseID]);
 
@@ -39,7 +32,7 @@ if (isset($_GET['warehouse_id'])) {
         }
     } else {
         try {
-            $pdo = new PDO("mysql:host=$host;dbname=$db;charset=utf8mb4", $user, $pass);
+            $pdo = getPDO();
             $stmt = $pdo->prepare("SELECT AisleNr, AisleName FROM Aisle WHERE WarehouseID = :warehouse_id");
             $stmt->execute(['warehouse_id' => $warehouseID]);
 

--- a/src/get_products.php
+++ b/src/get_products.php
@@ -1,5 +1,5 @@
 <?php
-require_once '/var/www/html/vendor/autoload.php';
+require_once __DIR__ . '/db.php';
 
 header('Content-Type: application/json');
 
@@ -10,9 +10,7 @@ if (isset($_GET['warehouse_id']) && isset($_GET['aisle_nr'])) {
 
     if ($useMongoDB) {
         try {
-            $mongoUri = 'mongodb://Irdi:Password1@MyMongoDBContainer:27017';
-            $mongoClient = new MongoDB\Client($mongoUri);
-            $mongoDb = $mongoClient->selectDatabase('IMSE_MS2');
+            $mongoDb = getMongoDb();
 
             // Fetch the warehouse to get the specific aisle
             $warehouse = $mongoDb->Warehouse->findOne(['warehouseID' => (int)$warehouseID]);
@@ -52,13 +50,9 @@ if (isset($_GET['warehouse_id']) && isset($_GET['aisle_nr'])) {
         }
     } else {
         // MySQL Implementation:
-        $host = 'MySQLDockerContainer';
-        $db = 'IMSE_MS2';
-        $user = 'root';
-        $pass = 'IMSEMS2';
 
         try {
-            $pdo = new PDO("mysql:host=$host;dbname=$db;charset=utf8mb4", $user, $pass);
+            $pdo = getPDO();
             $stmt = $pdo->prepare("
                 SELECT P.ProductID, P.Name, WI.Quantity
                   FROM WarehouseInventory WI
@@ -76,5 +70,4 @@ if (isset($_GET['warehouse_id']) && isset($_GET['aisle_nr'])) {
     }
 } else {
     echo json_encode(['error' => 'Warehouse ID and Aisle Nr not provided']);
-}
-?>
+}?>

--- a/src/insert_product.php
+++ b/src/insert_product.php
@@ -1,18 +1,6 @@
 <?php
 session_start();
-
-// MongoDB Configuration
-require_once '/var/www/html/vendor/autoload.php';
-$mongoUri = 'mongodb://Irdi:Password1@MyMongoDBContainer:27017';
-$mongoClient = new MongoDB\Client($mongoUri);
-$mongoDb = $mongoClient->selectDatabase('IMSE_MS2');
-
-// MySQL Configuration
-$host = 'MySQLDockerContainer'; // MySQL container name
-$db = 'IMSE_MS2';               // Database name
-$user = 'root';                 // MySQL username
-$pass = 'IMSEMS2';              // MySQL root password
-$dsn = "mysql:host=$host;dbname=$db;charset=utf8mb4";
+require_once __DIR__ . '/db.php';
 
 try {
     $useMongoDb = isset($_SESSION['use_mongodb']) && $_SESSION['use_mongodb'] === true;
@@ -26,6 +14,7 @@ try {
         $currency = $_POST['currency'] ?? null;
 
         if ($useMongoDb) {
+            $mongoDb = getMongoDb();
             $lastProduct = $mongoDb->Product->findOne([], [
                 'sort' => ['ProductID' => -1],
                 'projection' => ['ProductID' => 1]
@@ -46,8 +35,7 @@ try {
         
             $productID = $nextProductID;
         } else {
-            $pdo = new PDO($dsn, $user, $pass);
-            $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+            $pdo = getPDO();
 
             $stmt = $pdo->prepare(<<<SQL
                 INSERT INTO Product (Name, Description, Weight, UnitOfMeasure, Price, Currency)

--- a/src/insert_transfer.php
+++ b/src/insert_transfer.php
@@ -1,18 +1,6 @@
 <?php
 session_start();
-
-// MongoDB Configuration
-require_once '/var/www/html/vendor/autoload.php';
-$mongoUri = 'mongodb://Irdi:Password1@MyMongoDBContainer:27017';
-$mongoClient = new MongoDB\Client($mongoUri);
-$mongoDb = $mongoClient->selectDatabase('IMSE_MS2');
-
-// MySQL Configuration
-$host = 'MySQLDockerContainer';
-$db = 'IMSE_MS2';
-$user = 'root';
-$pass = 'IMSEMS2';
-$dsn = "mysql:host=$host;dbname=$db;charset=utf8mb4";
+require_once __DIR__ . '/db.php';
 
 try {
     $useMongoDb = isset($_SESSION['use_mongodb']) && $_SESSION['use_mongodb'] === true;
@@ -28,6 +16,7 @@ try {
         if ($useMongoDb) {
 
             try {
+                $mongoDb = getMongoDb();
                 $productIDs = isset($_POST['product_id']) ? $_POST['product_id'] : [];   // e.g. [101, 102, ...]
                 $quantities = isset($_POST['quantity']) ? $_POST['quantity'] : [];       // e.g. [10,  5,   ...]
 
@@ -259,8 +248,7 @@ try {
             }
         } else {
             try {
-                $pdo = new PDO($dsn, $user, $pass);
-                $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+                $pdo = getPDO();
                 $pdo->beginTransaction();
 
                 $stmt = $pdo->prepare("

--- a/src/insert_transfer_form.php
+++ b/src/insert_transfer_form.php
@@ -4,17 +4,13 @@ session_start();
 // Check if connected to MongoDB
 $useMongoDB = isset($_SESSION['use_mongodb']) && $_SESSION['use_mongodb'];
 
-// MongoDB Configuration
-require_once '/var/www/html/vendor/autoload.php';
-$mongoUri = 'mongodb://Irdi:Password1@MyMongoDBContainer:27017';
-$mongoClient = new MongoDB\Client($mongoUri);
-$mongoDb = $mongoClient->selectDatabase('IMSE_MS2');
+require_once __DIR__ . '/db.php';
 
-// MySQL Configuration
-$host = 'MySQLDockerContainer';
-$db = 'IMSE_MS2';
-$user = 'root';
-$pass = 'IMSEMS2';
+if ($useMongoDB) {
+    $mongoDb = getMongoDb();
+} else {
+    $pdo = getPDO();
+}
 ?>
 
 <!DOCTYPE html>
@@ -251,7 +247,7 @@ $pass = 'IMSEMS2';
                 }
             } else {
                 try {
-                    $pdo = new PDO("mysql:host=$host;dbname=$db;charset=utf8mb4", $user, $pass);
+                    $pdo = getPDO();
                     $stmt = $pdo->query("SELECT WarehouseID, WarehouseName FROM Warehouse");
                     foreach ($stmt as $row) {
                         echo "<option value='" . htmlspecialchars($row['WarehouseID']) . "'>" . htmlspecialchars($row['WarehouseName']) . "</option>";

--- a/src/insert_warehouse.php
+++ b/src/insert_warehouse.php
@@ -1,18 +1,6 @@
 <?php
 session_start();
-
-// MongoDB Configuration
-require_once '/var/www/html/vendor/autoload.php';
-$mongoUri = 'mongodb://Irdi:Password1@MyMongoDBContainer:27017';
-$mongoClient = new MongoDB\Client($mongoUri);
-$mongoDb = $mongoClient->selectDatabase('IMSE_MS2');
-
-// MySQL Configuration
-$host = 'MySQLDockerContainer'; // MySQL container name
-$db = 'IMSE_MS2';               // Database name
-$user = 'root';                 // MySQL username
-$pass = 'IMSEMS2';              // MySQL root password
-$dsn = "mysql:host=$host;dbname=$db;charset=utf8mb4";
+require_once __DIR__ . '/db.php';
 
 try {
     $useMongoDb = isset($_SESSION['use_mongodb']) && $_SESSION['use_mongodb'] === true;
@@ -26,6 +14,7 @@ try {
         $fireExtinguishers = $_POST['fire_extinguisher'] ?? [];
 
         if ($useMongoDb) {
+            $mongoDb = getMongoDb();
 
             $lastWarehouse = $mongoDb->Warehouse->findOne(
                 [],
@@ -64,8 +53,7 @@ try {
             echo "<p style='color:green;'>New warehouse and aisles added successfully</p>";
         } else {
 
-            $pdo = new PDO($dsn, $user, $pass);
-            $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+            $pdo = getPDO();
 
             $stmt = $pdo->prepare("
                 INSERT INTO Warehouse (WarehouseName, Address, Category)

--- a/src/migrate_to_mongodb.php
+++ b/src/migrate_to_mongodb.php
@@ -7,12 +7,10 @@ header("Access-Control-Allow-Methods: POST");
 header("Access-Control-Allow-Headers: Content-Type");
 header('Content-Type: application/json');
 
-require_once '/var/www/html/vendor/autoload.php';
+require_once __DIR__ . '/db.php';
 
 // MongoDB Configuration
-$uri = 'mongodb://Irdi:Password1@MyMongoDBContainer:27017';
-$mongoClient = new MongoDB\Client($uri);
-$mongoDb = $mongoClient->selectDatabase('IMSE_MS2');
+$mongoDb = getMongoDb();
 
 $mongoDb->Warehouse->drop();
 $mongoDb->Aisle->drop();
@@ -25,7 +23,7 @@ $mongoDb->TransferHeader->drop();
 $mongoDb->TransferLines->drop();
 $mongoDb->WarehouseInventory->drop();
 
-$mysqli = new mysqli("MySQLDockerContainer", "root", "IMSEMS2", "IMSE_MS2");
+$mysqli = getMySQLi();
 
 if ($mysqli->connect_error) {
     die("Connection failed: " . $mysqli->connect_error);

--- a/src/report_item_transfers.php
+++ b/src/report_item_transfers.php
@@ -1,22 +1,15 @@
 <?php
 session_start();
-
-// MongoDB Configuration
-require_once '/var/www/html/vendor/autoload.php';
-$mongoUri = 'mongodb://Irdi:Password1@MyMongoDBContainer:27017';
-$mongoClient = new MongoDB\Client($mongoUri);
-$mongoDb = $mongoClient->selectDatabase('IMSE_MS2');
-
-// MySQL Configuration
-$host = 'MySQLDockerContainer';
-$db = 'IMSE_MS2';
-$user = 'root';
-$pass = 'IMSEMS2';
-$dsn = "mysql:host=$host;dbname=$db;charset=utf8mb4";
+require_once __DIR__ . '/db.php';
 
 try {
     // Determine whether to use MongoDB or MySQL based on session
     $useMongoDb = isset($_SESSION['use_mongodb']) && $_SESSION['use_mongodb'] === true;
+    if ($useMongoDb) {
+        $mongoDb = getMongoDb();
+    } else {
+        $pdo = getPDO();
+    }
 
     $items = [];
     $transfers = [];
@@ -92,7 +85,6 @@ try {
         }
     } else {
         // MySQL logic
-        $pdo = new PDO($dsn, $user, $pass);
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
         $itemsStmt = $pdo->query("SELECT ProductID, Name FROM Product ORDER BY ProductID");

--- a/src/view_product.php
+++ b/src/view_product.php
@@ -1,16 +1,12 @@
 <?php
 session_start();
+require_once __DIR__ . '/db.php';
 
 // Check if connected to MongoDB
 $useMongoDB = isset($_SESSION['use_mongodb']) && $_SESSION['use_mongodb'];
 
 if ($useMongoDB) {
-    require_once '/var/www/html/vendor/autoload.php';
-
-    // MongoDB Configuration
-    $uri = 'mongodb://Irdi:Password1@MyMongoDBContainer:27017';
-    $mongoClient = new MongoDB\Client($uri);
-    $mongoDb = $mongoClient->selectDatabase('IMSE_MS2');
+    $mongoDb = getMongoDb();
 
     $productID = (int)($_GET['ProductID'] ?? null);
     $message = $_GET['message'] ?? null;
@@ -32,16 +28,10 @@ if ($useMongoDB) {
         exit;
     }
 } else {
-    // Database credentials
-    $host = 'MySQLDockerContainer'; // MySQL container name
-    $db = 'IMSE_MS2';               // Updated database name
-    $user = 'root';                 // MySQL username
-    $pass = 'IMSEMS2';              // MySQL root password
+    // MySQL connection
+    $pdo = getPDO();
 
     try {
-        $dsn = "mysql:host=$host;dbname=$db;charset=utf8mb4";
-        $pdo = new PDO($dsn, $user, $pass);
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
         $productID = (int)($_GET['ProductID'] ?? null);
         $message = $_GET['message'] ?? null;

--- a/src/view_products.php
+++ b/src/view_products.php
@@ -1,21 +1,14 @@
 <?php
 session_start();
-
-// MongoDB Configuration
-require_once '/var/www/html/vendor/autoload.php';
-$mongoUri = 'mongodb://Irdi:Password1@MyMongoDBContainer:27017';
-$mongoClient = new MongoDB\Client($mongoUri);
-$mongoDb = $mongoClient->selectDatabase('IMSE_MS2');
-
-// MySQL Configuration
-$host = 'MySQLDockerContainer';
-$db = 'IMSE_MS2';
-$user = 'root';
-$pass = 'IMSEMS2';
-$dsn = "mysql:host=$host;dbname=$db;charset=utf8mb4";
+require_once __DIR__ . '/db.php';
 
 try {
     $useMongoDb = isset($_SESSION['use_mongodb']) && $_SESSION['use_mongodb'] === true;
+    if ($useMongoDb) {
+        $mongoDb = getMongoDb();
+    } else {
+        $pdo = getPDO();
+    }
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_id'])) {
         $deleteID = $_POST['delete_id'];
@@ -31,8 +24,6 @@ try {
             }
         } else {
             try {
-                $pdo = new PDO($dsn, $user, $pass);
-                $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
                 $deleteStmt = $pdo->prepare("DELETE FROM Product WHERE ProductID = :ProductID");
                 $deleteStmt->execute([':ProductID' => $deleteID]);
@@ -59,8 +50,7 @@ try {
             ];
         }
     } else {
-        $pdo = new PDO($dsn, $user, $pass);
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo = getPDO();
         $stmt = $pdo->query("SELECT * FROM Product");
         $products = $stmt->fetchAll(PDO::FETCH_ASSOC);
     }

--- a/src/view_transfer.php
+++ b/src/view_transfer.php
@@ -1,21 +1,14 @@
 <?php
 session_start();
-
-// MongoDB Configuration
-require_once '/var/www/html/vendor/autoload.php';
-$mongoUri = 'mongodb://Irdi:Password1@MyMongoDBContainer:27017';
-$mongoClient = new MongoDB\Client($mongoUri);
-$mongoDb = $mongoClient->selectDatabase('IMSE_MS2');
-
-// MySQL Configuration
-$host = 'MySQLDockerContainer'; // MySQL container name
-$db = 'IMSE_MS2';               // Database name
-$user = 'root';                 // MySQL username
-$pass = 'IMSEMS2';              // MySQL root password
-$dsn = "mysql:host=$host;dbname=$db;charset=utf8mb4";
+require_once __DIR__ . '/db.php';
 
 try {
     $useMongoDb = isset($_SESSION['use_mongodb']) && $_SESSION['use_mongodb'] === true;
+    if ($useMongoDb) {
+        $mongoDb = getMongoDb();
+    } else {
+        $pdo = getPDO();
+    }
 
     if ($useMongoDb) {
         if (!isset($_GET['TransferID'])) {
@@ -80,9 +73,6 @@ try {
         }
         $lines = $formattedLines;
     } else {
-
-        $pdo = new PDO($dsn, $user, $pass);
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
         if (!isset($_GET['TransferID'])) {
             throw new Exception("TransferID not provided.");

--- a/src/view_transfers.php
+++ b/src/view_transfers.php
@@ -1,21 +1,14 @@
 <?php
 session_start();
-
-// MongoDB Configuration
-require_once '/var/www/html/vendor/autoload.php';
-$mongoUri = 'mongodb://Irdi:Password1@MyMongoDBContainer:27017';
-$mongoClient = new MongoDB\Client($mongoUri);
-$mongoDb = $mongoClient->selectDatabase('IMSE_MS2');
-
-// MySQL Configuration
-$host = 'MySQLDockerContainer'; // MySQL container name
-$db = 'IMSE_MS2';               // Database name
-$user = 'root';                 // MySQL username
-$pass = 'IMSEMS2';              // MySQL root password
-$dsn = "mysql:host=$host;dbname=$db;charset=utf8mb4";
+require_once __DIR__ . '/db.php';
 
 try {
     $useMongoDb = isset($_SESSION['use_mongodb']) && $_SESSION['use_mongodb'] === true;
+    if ($useMongoDb) {
+        $mongoDb = getMongoDb();
+    } else {
+        $pdo = getPDO();
+    }
 
     if ($useMongoDb) {
         $transfers = $mongoDb->TransferHeader->find([], [
@@ -66,8 +59,6 @@ try {
         }
     } else {
         // MySQL logic
-        $pdo = new PDO($dsn, $user, $pass);
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
         $stmt = $pdo->prepare("
             SELECT th.TransferID, th.TransferDate, 

--- a/src/view_warehouse.php
+++ b/src/view_warehouse.php
@@ -1,21 +1,14 @@
 <?php
 session_start();
-
-// MongoDB Configuration
-require_once '/var/www/html/vendor/autoload.php';
-$mongoUri = 'mongodb://Irdi:Password1@MyMongoDBContainer:27017';
-$mongoClient = new MongoDB\Client($mongoUri);
-$mongoDb = $mongoClient->selectDatabase('IMSE_MS2');
-
-// MySQL Configuration
-$host = 'MySQLDockerContainer'; // MySQL container name
-$db = 'IMSE_MS2';               // Database name
-$user = 'root';                 // MySQL username
-$pass = 'IMSEMS2';              // MySQL root password
-$dsn = "mysql:host=$host;dbname=$db;charset=utf8mb4";
+require_once __DIR__ . '/db.php';
 
 try {
     $useMongoDb = isset($_SESSION['use_mongodb']) && $_SESSION['use_mongodb'] === true;
+    if ($useMongoDb) {
+        $mongoDb = getMongoDb();
+    } else {
+        $pdo = getPDO();
+    }
 
     $warehouseName = $_GET['WarehouseName'] ?? null;
 
@@ -80,8 +73,7 @@ try {
         $warehouse = $formattedWarehouse;
     } else {
         // MySQL logic
-        $pdo = new PDO($dsn, $user, $pass);
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo = getPDO();
 
         $stmt = $pdo->prepare("SELECT * FROM Warehouse WHERE WarehouseName = :WarehouseName");
         $stmt->execute([':WarehouseName' => $warehouseName]);

--- a/src/view_warehouses.php
+++ b/src/view_warehouses.php
@@ -1,21 +1,14 @@
 <?php
 session_start();
-
-// MongoDB Configuration
-require_once '/var/www/html/vendor/autoload.php';
-$mongoUri = 'mongodb://Irdi:Password1@MyMongoDBContainer:27017';
-$mongoClient = new MongoDB\Client($mongoUri);
-$mongoDb = $mongoClient->selectDatabase('IMSE_MS2');
-
-// MySQL Configuration
-$host = 'MySQLDockerContainer'; // MySQL container name
-$db = 'IMSE_MS2';               // Database name
-$user = 'root';                 // MySQL username
-$pass = 'IMSEMS2';              // MySQL root password
-$dsn = "mysql:host=$host;dbname=$db;charset=utf8mb4";
+require_once __DIR__ . '/db.php';
 
 try {
     $useMongoDb = isset($_SESSION['use_mongodb']) && $_SESSION['use_mongodb'] === true;
+    if ($useMongoDb) {
+        $mongoDb = getMongoDb();
+    } else {
+        $pdo = getPDO();
+    }
 
     if ($useMongoDb) {
         $warehousesCursor = $mongoDb->Warehouse->find([], [
@@ -23,8 +16,7 @@ try {
         ]);
         $warehouses = iterator_to_array($warehousesCursor);
     } else {
-        $pdo = new PDO($dsn, $user, $pass);
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo = getPDO();
 
         $stmt = $pdo->query("SELECT * FROM Warehouse ORDER BY WarehouseID");
         $warehouses = $stmt->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
## Summary
- create `src/db.php` with functions to get MongoDB, PDO, and MySQLi connections
- include the new `db.php` across scripts
- replace ad-hoc connection code with calls to `getMongoDb()`, `getPDO()`, and `getMySQLi()`
- remove repeated credentials from individual PHP files

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d5a7ad42883289738f4e4cc690b98