### PR TITLE
Add PHPUnit and sample test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# IMSE_MS2-Irdi-Kuka
+
+This project uses Composer for dependency management. Development tests are written with PHPUnit.
+
+## Running Tests
+
+1. Install Composer dependencies:
+
+```bash
+cd src
+composer install
+```
+
+2. Run the test suite from the project root:
+
+```bash
+./src/vendor/bin/phpunit
+```
+
+The default configuration loads tests from the `tests/` directory.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="src/util.php">
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/composer.json
+++ b/src/composer.json
@@ -5,9 +5,11 @@
         "fakerphp/faker": "^1.16",
         "mongodb/mongodb": "^1.12.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6"
+    },
     "autoload": {
         "psr-4": {
             "App\\": "src/"
         }
-    }
-}
+    }}

--- a/src/util.php
+++ b/src/util.php
@@ -1,0 +1,10 @@
+<?php
+namespace App;
+
+/**
+ * Build a MySQL DSN string using host and database name.
+ */
+function build_mysql_dsn(string $host, string $db): string
+{
+    return "mysql:host=$host;dbname=$db;charset=utf8mb4";
+}

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -1,0 +1,11 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class UtilTest extends TestCase
+{
+    public function testBuildMysqlDsn()
+    {
+        $dsn = App\build_mysql_dsn('localhost', 'testdb');
+        $this->assertSame('mysql:host=localhost;dbname=testdb;charset=utf8mb4', $dsn);
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit as a dev dependency
- document running the tests
- provide phpunit configuration
- create a simple DSN helper and PHPUnit test

## Testing
- `./src/vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686d5a7b3d5c8328be0e784e09997fcc