### PR TITLE
Implement CSRF tokens

### DIFF
--- a/src/insert_transfer_form.php
+++ b/src/insert_transfer_form.php
@@ -1,6 +1,10 @@
 <?php
 session_start();
 
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
 // Check if connected to MongoDB
 $useMongoDB = isset($_SESSION['use_mongodb']) && $_SESSION['use_mongodb'];
 
@@ -310,6 +314,8 @@ $pass = 'IMSEMS2';
                 <input type="number" name="quantity[]" placeholder="Enter Quantity" min="1" required>
             </div>
         </div>
+
+        <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
 
         <input type="submit" value="Create Transfer" class="btn">
     </form>


### PR DESCRIPTION
## Summary
- add CSRF token generation and verification in product and transfer forms
- regenerate tokens on redirects after processing

## Testing
- `php -l src/insert_product.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d5a7bc49c8328b3c94fb15937ba50